### PR TITLE
Make network generic over activator functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 To create a new neural network you can use the following. This creates a network that takes two inputs, has two hidden neurons and gives one output.
 
 ```rs
-let mut nn = FeedForward::<2, 2, 1>::new();
+let mut nn = FeedForward::<Sigmoid, 2, 2, 1>::new();
 ```
 
 Then given some training data like this:

--- a/examples/predict_xor.rs
+++ b/examples/predict_xor.rs
@@ -1,4 +1,4 @@
-use fnn::{na::SVector, FeedForward};
+use fnn::{na::SVector, FeedForward, Sigmoid};
 
 fn main() {
     // Create a new feed forward neural network.
@@ -10,7 +10,7 @@ fn main() {
     //
     // The number of hidden layers is something you can tune. I found that for
     // this example any more than 2 did not result in any accuracy improvement.
-    let mut nn = FeedForward::<2, 2, 1>::new();
+    let mut nn = FeedForward::<Sigmoid, 2, 2, 1>::new();
 
     // Data
     let training_data = [

--- a/src/activator.rs
+++ b/src/activator.rs
@@ -1,0 +1,108 @@
+/// A trait providing [activation functions](https://en.wikipedia.org/wiki/Activation_function).
+pub trait Activator {
+    fn activate(x: f64) -> f64;
+    fn derivative(x: f64) -> f64;
+}
+
+/// The Sigmoid activation function.
+/// Outputs values between 0 and 1, commonly used for binary classification tasks.
+pub struct Sigmoid;
+impl Activator for Sigmoid {
+    fn activate(x: f64) -> f64 {
+        1.0 / (1.0 + libm::exp(-x))
+    }
+    fn derivative(x: f64) -> f64 {
+        let s = Sigmoid::activate(x);
+        s * (1.0 - s)
+    }
+}
+
+/// The Tanh activation function.
+/// Outputs values between -1 and 1, providing a zero-centered activation.
+/// Often used in recurrent neural networks.
+pub struct Tanh;
+impl Activator for Tanh {
+    fn activate(x: f64) -> f64 {
+        libm::tanh(x)
+    }
+    fn derivative(x: f64) -> f64 {
+        1.0 - libm::pow(libm::tanh(x), 2.0)
+    }
+}
+
+/// The Swish activation function.
+/// A newer activation function defined as `x * sigmoid(x)`.
+/// Known to outperform ReLU in some deep networks.
+pub struct Swish;
+impl Activator for Swish {
+    fn activate(x: f64) -> f64 {
+        x * (1.0 / (1.0 + libm::exp(-x)))
+    }
+
+    fn derivative(x: f64) -> f64 {
+        let sigmoid_x = 1.0 / (1.0 + libm::exp(-x));
+        sigmoid_x + x * sigmoid_x * (1.0 - sigmoid_x)
+    }
+}
+
+/// The ReLU (Rectified Linear Unit) activation function.
+/// Outputs the input directly if positive; otherwise, outputs zero.
+/// Commonly used in deep neural networks due to its simplicity and efficiency.
+pub struct ReLU;
+impl Activator for ReLU {
+    fn activate(x: f64) -> f64 {
+        x.max(0.0)
+    }
+
+    fn derivative(x: f64) -> f64 {
+        if x > 0.0 {
+            1.0
+        } else {
+            0.0
+        }
+    }
+}
+
+/// The Leaky ReLU activation function.
+/// A variant of ReLU that allows a small, non-zero gradient when the input is negative,
+/// which helps mitigate the "dead neuron" issue in ReLU.
+pub struct LeakyReLU;
+impl Activator for LeakyReLU {
+    fn activate(x: f64) -> f64 {
+        if x > 0.0 {
+            x
+        } else {
+            0.01 * x
+        }
+    }
+
+    fn derivative(x: f64) -> f64 {
+        if x > 0.0 {
+            1.0
+        } else {
+            0.01
+        }
+    }
+}
+
+/// The ELU (Exponential Linear Unit) activation function.
+/// Outputs `x` if positive; otherwise, outputs an exponential curve for negative values,
+/// improving gradient flow and learning dynamics in deeper networks.
+pub struct ELU;
+impl Activator for ELU {
+    fn activate(x: f64) -> f64 {
+        if x > 0.0 {
+            x
+        } else {
+            libm::exp(x) - 1.0
+        }
+    }
+
+    fn derivative(x: f64) -> f64 {
+        if x > 0.0 {
+            1.0
+        } else {
+            libm::exp(x)
+        }
+    }
+}


### PR DESCRIPTION
This adds a new `Activator` trait which provides the function along with its derivative function. Common functions have been implemented each with a summary from chatgpt.