### PR TITLE
Make simple_hash not const

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ impl<A: Activator, const INPUTS: usize, const HIDDEN: usize, const OUTPUT: usize
     }
 }
 
-const fn simple_hash(x: usize, y: usize) -> f64 {
+fn simple_hash(x: usize, y: usize) -> f64 {
     let h = (x.wrapping_mul(31).wrapping_add(y)) as f64;
     (h % 100.0) / 100.0 - 0.5
 }


### PR DESCRIPTION
Float arithmetic is only a recent addition and to make sure older versions like the nightly recommended by avr-hal can still compile this I remove const. It didn't make any difference anyway as it is not used in const contexts.